### PR TITLE
Fix incorrect lookup of global jQuery variable.

### DIFF
--- a/phantomcss.js
+++ b/phantomcss.js
@@ -110,6 +110,7 @@ function turnOffAnimations() {
 	casper.evaluate( function turnOffAnimations() {
 
 		function disableAnimations() {
+			var jQuery = window.jQuery;
 			if ( jQuery ) {
 				jQuery.fx.off = true;
 			}
@@ -614,6 +615,7 @@ function setVisibilityToHidden( s1, s2 ) {
 	var elements;
 	var i;
 
+	var jQuery = window.jQuery;
 	if ( jQuery ) {
 		if ( s1 ) {
 			jQuery( s1 ).css( 'visibility', 'hidden' );


### PR DESCRIPTION
You need to look into the `window` variable or it will throw an undefined error.

@jamescryer Please update the `PhantomCSS` and `PhantomFlow` packages after merging this.