### PR TITLE
Adding SlimerJS Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 PhantomCSS
 ==========
 
-**CSS regression testing**. A [CasperJS](http://github.com/n1k0/casperjs) module for automating visual regression testing with [PhantomJS](http://github.com/ariya/phantomjs/) and [Resemble.js](http://huddle.github.com/Resemble.js/). For testing Web apps, live style guides and responsive layouts. Read more on Huddle's Engineering blog: [CSS Regression Testing](http://tldr.huddle.com/blog/css-testing/).
+**CSS regression testing**. A [CasperJS](http://github.com/n1k0/casperjs) module for automating visual regression testing with [PhantomJS](http://github.com/ariya/phantomjs/) or [SlimerJS](http://slimerjs.org/) and [Resemble.js](http://huddle.github.com/Resemble.js/). For testing Web apps, live style guides and responsive layouts. Read more on Huddle's Engineering blog: [CSS Regression Testing](http://tldr.huddle.com/blog/css-testing/).
 
 ### What?
 
@@ -29,9 +29,14 @@ casper.
 	});
 ```
 
-From the command line/terminal run
+From the command line/terminal run:
 
 * `casperjs test demo/testsuite.js`
+
+Some useful CasperJS CLI options:
+* `casperjs test --verbose --log-level=debug demo/testsuite.js`
+* `casperjs test demo/testsuite.js --engine=slimerjs`
+* `casperjs test demo/testsuite.js --engine=phantomjs`
 
 ### Download
 
@@ -57,7 +62,8 @@ phantomcss.init({
 	/*
 		libraryRoot is relative to this file and must point to your 
 		phantomcss folder (not lib or node_modules). If you are using 
-		NPM, this will be './node_modules/phantomcss'
+		NPM, this will be './node_modules/phantomcss'. If you are using
+		SlimerJS, you will need absolute paths (see 'demo').
 	*/
 	libraryRoot: './modules/PhantomCSS',
 	
@@ -67,15 +73,22 @@ phantomcss.init({
 		By default, failure images are put in the './failures' folder. 
 		If failedComparisonsRoot is set to false a separate folder will 
 		not be created but failure images can still be found alongside 
-		the original and new images.
+		the original and new images. If you are using
+		SlimerJS, you will need absolute paths (see 'demo').
 	*/
 	failedComparisonsRoot: './failures',
 
 	/*
 		Remove results directory tree after run.  Use in conjunction 
-		with failedComparisonsRoot to see failed comparisons
+		with failedComparisonsRoot to see failed comparisons. If you are using
+		SlimerJS, you will need absolute paths (see 'demo').
 	*/
 	cleanupComparisonImages: true,
+
+	/*
+		A reference to a particular Casper instance. Required for SlimerJS.
+	*/
+	casper: specific_instance_of_casper,
 
 	/*
 		You might want to keep master/baseline images in a completely 

--- a/demo/testsuite.js
+++ b/demo/testsuite.js
@@ -2,12 +2,22 @@
 	Require and initialise PhantomCSS module
 	Paths are relative to CasperJs directory
 */
-var phantomcss = require('./../phantomcss.js');
+
+
+var fs = require('fs');
+var path = fs.absolute(fs.workingDirectory + '/../phantomcss.js');
+var phantomcss = require(path);
 
 casper.test.begin('Coffee machine visual tests', 5, function(test) {
 
 	phantomcss.init({
-		rebase: casper.cli.get("rebase")
+		rebase: casper.cli.get("rebase"),
+		// SlimerJS needs explicit knowledge of this Casper, and lots of absolute paths
+		casper: casper,
+		libraryRoot: fs.absolute(fs.workingDirectory + '/..'),
+		screenshotRoot: fs.absolute(fs.workingDirectory + '/screenshots'),
+		failedComparisonsRoot: fs.absolute(fs.workingDirectory + '/failures'),
+		addLabelToFailedImage: false,
 		/*
 		screenshotRoot: '/screenshots',
 		failedComparisonsRoot: '/failures'
@@ -31,11 +41,21 @@ casper.test.begin('Coffee machine visual tests', 5, function(test) {
 		}*/
 	});
 
+	casper.on('remote.message', function(msg) {
+		this.echo(msg);
+	})
 
+	casper.on('error', function(err) {
+		this.die("PhantomJS has errored: " + err);
+	});
+
+	casper.on('resourceError', function(err) {
+		casper.log('Resource load error: ' + err, 'warning');
+	});
 	/*
 		The test scenario
 	*/
-	casper.start( './demo/coffeemachine.html' );
+	casper.start( fs.absolute(fs.workingDirectory + '/coffeemachine.html'));
 
 	casper.viewport(1024, 768);
 

--- a/demo/testsuite.js
+++ b/demo/testsuite.js
@@ -5,18 +5,18 @@
 
 
 var fs = require('fs');
-var path = fs.absolute(fs.workingDirectory + '/../phantomcss.js');
+var path = fs.absolute(fs.workingDirectory + '/phantomcss.js');
 var phantomcss = require(path);
-
+console.log(path);
 casper.test.begin('Coffee machine visual tests', 5, function(test) {
 
 	phantomcss.init({
 		rebase: casper.cli.get("rebase"),
 		// SlimerJS needs explicit knowledge of this Casper, and lots of absolute paths
 		casper: casper,
-		libraryRoot: fs.absolute(fs.workingDirectory + '/..'),
-		screenshotRoot: fs.absolute(fs.workingDirectory + '/screenshots'),
-		failedComparisonsRoot: fs.absolute(fs.workingDirectory + '/failures'),
+		libraryRoot: fs.absolute(fs.workingDirectory + ''),
+		screenshotRoot: fs.absolute(fs.workingDirectory + '/demo/screenshots'),
+		failedComparisonsRoot: fs.absolute(fs.workingDirectory + '/demo/failures'),
 		addLabelToFailedImage: false,
 		/*
 		screenshotRoot: '/screenshots',
@@ -55,7 +55,7 @@ casper.test.begin('Coffee machine visual tests', 5, function(test) {
 	/*
 		The test scenario
 	*/
-	casper.start( fs.absolute(fs.workingDirectory + '/coffeemachine.html'));
+	casper.start( fs.absolute(fs.workingDirectory + '/demo/coffeemachine.html'));
 
 	casper.viewport(1024, 768);
 

--- a/libs/resemblejs/resemble.js
+++ b/libs/resemblejs/resemble.js
@@ -55,6 +55,7 @@ URL: https://github.com/Huddle/Resemble.js
 
 		var ignoreAntialiasing = false;
 		var ignoreColors = false;
+		var ignoreCrossDomain = false;
 
 		function triggerDataUpdate(){
 			var len = updateCallbackArray.length;
@@ -110,8 +111,9 @@ URL: https://github.com/Huddle/Resemble.js
 		function loadImageData( fileData, callback ){
 			var fileReader;
 			var hiddenImage = new Image();
-                        hiddenImage.setAttribute("crossOrigin", "crossOrigin");
-
+			if (!ignoreCrossDomain) {
+				hiddenImage.setAttribute("crossOrigin", "crossOrigin");
+			}
 			hiddenImage.onload = function() {
 
 				var hiddenCanvas =  document.createElement('canvas');
@@ -542,6 +544,13 @@ URL: https://github.com/Huddle/Resemble.js
 
 					ignoreAntialiasing = false;
 					ignoreColors = true;
+
+					if(hasMethod) { param(); }
+					return self;
+				},
+				ignoreCrossDomain: function(){
+
+					ignoreCrossDomain = true;
 
 					if(hasMethod) { param(); }
 					return self;

--- a/phantomcss.js
+++ b/phantomcss.js
@@ -182,7 +182,7 @@ function screenshot( target, timeToWait, hideSelector, fileName ) {
 }
 
 function isComponentsConfig( obj ) {
-	return ( obj instanceof Object ) && ( isClipRect( obj ) === false );
+	return ( Object.prototype.toString.call(obj) == '[object Object]' ) && ( isClipRect( obj ) === false );
 }
 
 function grab(filepath, target){

--- a/phantomcss.js
+++ b/phantomcss.js
@@ -275,7 +275,7 @@ function asyncCompare( one, two, func ) {
 		initClient();
 	}
 
-	casper.fill( 'form#image-diff', {
+	casper.fill( 'form#image-diff-form', {
 		'one': one,
 		'two': two
 	} );
@@ -518,6 +518,7 @@ function initClient() {
 			// this is a bit of hack, need to get images into browser for analysis
 			div.style = "display:block;position:absolute;border:0;top:10px;left:0;";
 			// div.style = "display:block;position:absolute;border:0;top:0;left:0;height:1px;width:1px;";
+			div.innerHTML = '<form id="image-diff-form">' +
 				'<input type="file" id="image-diff-one" name="one"/>' +
 				'<input type="file" id="image-diff-two" name="two"/>' +
 				'</form><div id="image-diff"></div>';

--- a/phantomcss.js
+++ b/phantomcss.js
@@ -98,9 +98,9 @@ function init( options ) {
 function getResemblePath( root ) {
 
 	var path = [ root, 'libs', 'resemblejs', 'resemble.js' ].join( fs.separator );
-	if ( !fs.isFile( path ) ) {
+	if ( !_isFile( path ) ) {
 		path = [ root, 'node_modules', 'resemblejs', 'resemble.js' ].join( fs.separator );
-		if ( !fs.isFile( path ) ) {
+		if ( !_isFile( path ) ) {
 			throw "[PhantomCSS] Resemble.js not found: " + path;
 		}
 	}
@@ -137,8 +137,7 @@ function _fileNameGetter( root, fileName ) {
 
 	fileName = fileName || "screenshot";
 	name = root + fs.separator + fileName + "_" + _count++;
-
-	if ( fs.isFile( name + '.png' ) ) {
+	if ( _isFile( name + '.png' ) ) {
 		return name + '.diff.png';
 	} else {
 		return name + '.png';
@@ -147,6 +146,19 @@ function _fileNameGetter( root, fileName ) {
 
 function _replaceDiffSuffix(str){
 	return str.replace( '.diff', '' );
+}
+
+function _isFile(path) {
+	var exists = false;
+	try {
+		exists = fs.isFile(path);
+	} catch (e) {
+		if (e.name != 'NS_ERROR_FILE_TARGET_DOES_NOT_EXIST') {
+			// We weren't expecting this exception
+			throw e;
+		}
+	}
+	return exists;
 }
 
 function screenshot( target, timeToWait, hideSelector, fileName ) {
@@ -250,7 +262,7 @@ function copyAndReplaceFile( src, dest ) {
 }
 
 function removeFile(filepath){
-	if ( fs.isFile( filepath ) ) {
+	if ( _isFile( filepath ) ) {
 		fs.remove( filepath );
 	}	
 }
@@ -368,11 +380,11 @@ function compareFiles( baseFile, file ) {
 		filename: baseFile
 	};
 
-	if ( !fs.isFile( baseFile ) ) {
+	if ( !_isFile( baseFile ) ) {
 		test.error = true;
 	} else {
 
-		if ( !fs.isFile( _resembleContainerPath ) ) {
+		if ( !_isFile( _resembleContainerPath ) ) {
 			console.log( '[PhantomCSS] Can\'t find Resemble container. Perhaps the library root is mis configured. (' + _resembleContainerPath + ')' );
 			test.error = true;
 			return;
@@ -401,7 +413,7 @@ function compareFiles( baseFile, file ) {
 								safeFileName = failFile;
 								increment = 0;
 
-								while ( fs.isFile( safeFileName + '.fail.png' ) ) {
+								while ( _isFile( safeFileName + '.fail.png' ) ) {
 									increment++;
 									safeFileName = failFile + '.' + increment;
 								}

--- a/phantomcss.js
+++ b/phantomcss.js
@@ -238,7 +238,7 @@ function capture( srcPath, resultPath, target ) {
 		}
 
 	} catch ( ex ) {
-		console.log( "[PhantomCSS] Screenshot capture failed: ", ex.message );
+		console.log( "[PhantomCSS] Screenshot capture failed: " + ex.message );
 	}
 }
 
@@ -338,7 +338,7 @@ function getDiffs( path ) {
 			if ( _test_match ) {
 				if ( _test_match.test( _realPath.toLowerCase() ) ) {
 					if ( !( _test_exclude && _test_exclude.test( _realPath.toLowerCase() ) ) ) {
-						console.log( '[PhantomCSS] Analysing', _realPath );
+						console.log( '[PhantomCSS] Analysing ' + _realPath );
 						_diffsToProcess.push( filePath );
 					}
 				}
@@ -422,7 +422,7 @@ function compareFiles( baseFile, file ) {
 								casper.captureSelector( failFile, 'img' );
 
 								test.failFile = failFile;
-								console.log( 'Failure! Saved to', failFile );
+								console.log( 'Failure! Saved to ' + failFile );
 							}
 
 							if ( file.indexOf( '.diff.png' ) !== -1 ) {

--- a/phantomcss.js
+++ b/phantomcss.js
@@ -552,6 +552,7 @@ function initClient() {
 				resemble( document.getElementById( 'image-diff-one' ).files[ 0 ] ).
 				compareTo( document.getElementById( 'image-diff-two' ).files[ 0 ] ).
 				ignoreAntialiasing(). // <-- muy importante
+				ignoreCrossDomain().
 				onComplete( function ( data ) {
 					var diffImage;
 

--- a/phantomcss.js
+++ b/phantomcss.js
@@ -516,8 +516,8 @@ function initClient() {
 			var div = document.createElement( 'div' );
 
 			// this is a bit of hack, need to get images into browser for analysis
-			div.style = "display:block;position:absolute;border:0;top:-1px;left:-1px;height:1px;width:1px;overflow:hidden;";
-			div.innerHTML = '<form id="image-diff">' +
+			div.style = "display:block;position:absolute;border:0;top:10px;left:0;";
+			// div.style = "display:block;position:absolute;border:0;top:0;left:0;height:1px;width:1px;";
 				'<input type="file" id="image-diff-one" name="one"/>' +
 				'<input type="file" id="image-diff-two" name="two"/>' +
 				'</form><div id="image-diff"></div>';


### PR DESCRIPTION
This adds drop-in [SlimerJS](http://slimerjs.org/) support to PhantomCSS - in part addresses #39. SlimerJS adds better support for webfonts, iconfonts etc.

You can now run the demo suite with `casperjs test demo/testsuite.js --engine=slimerjs`.

The main requirement of SlimerJS is the use of absolute paths. SlimerJS/PhantomCSS fails silently for me when it can't load files. So if SlimerJS fails like that, check the paths are right.

There's also a change to the resemble.js package to make the cross-domain setting optional which was also breaking SlimerJS... silently.

*Tested with the SlimerJS 'Lightweight Edition 0.9.5' and Firefox 35.0.1, with 'application.ini' patched to allow this higher version number.*