### PR TITLE
correct suspected type in demo `testsuite.js`

### DIFF
--- a/demo/testsuite.js
+++ b/demo/testsuite.js
@@ -48,7 +48,7 @@ casper.test.begin( 'Coffee machine visual tests', function ( test ) {
 		this.die( "PhantomJS has errored: " + err );
 	} );
 
-	casper.on( 'resourceError', function ( err ) {
+	casper.on( 'resource.error', function ( err ) {
 		casper.log( 'Resource load error: ' + err, 'warning' );
 	} );
 	/*


### PR DESCRIPTION
Looking through the CasperJS docs, I'm suspecting the `resource.error` Event was meant to be used here.
http://casperjs.readthedocs.org/en/latest/events-filters.html#resource-error
