### PR TITLE
Exposes a method for reseting the count. This allows the user to flui…

### DIFF
--- a/phantomcss.js
+++ b/phantomcss.js
@@ -38,6 +38,7 @@ exports.compareSession = compareSession;
 exports.compareFiles = compareFiles;
 exports.waitForTests = waitForTests;
 exports.init = init;
+exports.done = done;
 exports.update = update;
 exports.turnOffAnimations = turnOffAnimations;
 exports.getExitStatus = getExitStatus;
@@ -96,6 +97,10 @@ function update( options ) {
 
 function init( options ) {
 	update( options );
+}
+
+function done(){
+	_count = 0;
 }
 
 function getResemblePath( root ) {


### PR DESCRIPTION
Hey awesome project guys. This pull request exposes a method that allows the user to reset the count, so that phantomcss can be used to test in place. (Hopefully) Motivating casper test:

['mode 1', 'mode 2'].forEach(function(mode){  
  casper.test.begin('example with ' + mode, function suite(test) {
    phantomcss.init( { .... 	} );
    
    casper.options.viewportSize = {width: 1024, height: 768};
    casper.start('http://localhost:8082/vision/');
        
    casper.then(function(){
      casper.evaluate(function(mode){
             engageMode(mode) 
      }, mode)
      phantomcss.screenshot('#target, 'base');
      phantomcss.compareAll();
    });
       
    casper.run(function() {
      phantomcss.done();
      test.done();
    });
  });
});

(presumes that the folder the images are being saved into is empty)

The need for this method came up for me when constructing a system that mostly uses canvas rendering, but switches to svg for export. Rather than updating the base screenshots every time I made a change to the canvas, I felt like just running the image diff script twice was more succinct than manually updating the images. 