### PR TITLE
Support npm@3 using native Node module lookup

### DIFF
--- a/phantomcss.js
+++ b/phantomcss.js
@@ -115,7 +115,7 @@ function getResemblePath( root ) {
 
 	var path = [ root, 'libs', 'resemblejs', 'resemble.js' ].join( fs.separator );
 	if ( !_isFile( path ) ) {
-		path = [ root, 'node_modules', 'resemblejs', 'resemble.js' ].join( fs.separator );
+		path = require.resolve( 'resemblejs/resemble.js' );
 		if ( !_isFile( path ) ) {
 			throw "[PhantomCSS] Resemble.js not found: " + path;
 		}


### PR DESCRIPTION
Similar to the PR by @unional, but this uses Node's built-in `require.resolve` function to perform the lookup, which guarantees that it will be found based on Node's lookup rules.  This works with both npm@2 and npm@3.