### PR TITLE
Add options.addIteratorToImage

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,12 @@ phantomcss.init({
 	*/
 	comparisonResultRoot: './results',
 
+	/* 
+		Don't add count number to images. If set to false, a filename is 
+		required when capturing screenshots.
+	*/
+	addIteratorToImage: false,
+
 	/*
 		Don't add label to generated failure image
 	*/

--- a/phantomcss.js
+++ b/phantomcss.js
@@ -29,6 +29,7 @@ var _resembleContainerPath;
 var _libraryRoot;
 var _rebase = false;
 var _prefixCount = false;
+var _isCount = true;
 
 var _baselineImageSuffix = "";
 var _diffImageSuffix = ".diff";
@@ -73,6 +74,7 @@ function update( options ) {
 	_fileNameGetter = options.fileNameGetter || _fileNameGetter;
 
 	_prefixCount = options.prefixCount || _prefixCount;
+	_isCount = ( options.addIteratorToImage !== false );
 
 	_onPass = options.onPass || _onPass;
 	_onFail = options.onFail || _onFail;
@@ -154,12 +156,22 @@ function turnOffAnimations() {
 function _fileNameGetter( root, fileName ) {
 	var name;
 
+	// If no iterator, enforce filename.
+	if ( !_isCount && !fileName ) {
+		throw 'Filename is required when addIteratorToImage option is false.';
+	}
+
 	fileName = fileName || "screenshot";
 
-	if (_prefixCount) {
-		name = root + fs.separator + _count++ + "_" + fileName;
+	if ( !_isCount ) {
+		name = root + fs.separator + fileName;
+		_count++;
 	} else {
-		name = root + fs.separator + fileName + "_" + _count++;
+		if ( _prefixCount ) {
+			name = root + fs.separator + _count++ + "_" + fileName;
+		} else {
+			name = root + fs.separator + fileName + "_" + _count++;
+		}
 	}
 
 	if ( _isFile( name + _baselineImageSuffix + '.png' ) ) {


### PR DESCRIPTION
This update allows option to suppress the iterator in screenshot filenames by setting the option `addIteratorToImage: false`.