### PR TITLE
Allow _results to be updated when a new screenshot root is set.

### DIFF
--- a/phantomcss.js
+++ b/phantomcss.js
@@ -66,7 +66,7 @@ function update( options ) {
 	_resembleContainerPath = _resembleContainerPath || getResembleContainerPath( _libraryRoot );
 
 	_src = stripslash( options.screenshotRoot || _src );
-	_results = stripslash( options.comparisonResultRoot || _src || _results );
+	_results = stripslash( options.comparisonResultRoot || options.screenshotRoot || _results );
 	_failures = options.failedComparisonsRoot === false ? false : stripslash( options.failedComparisonsRoot || _failures );
 
 	_fileNameGetter = options.fileNameGetter || _fileNameGetter;

--- a/phantomcss.js
+++ b/phantomcss.js
@@ -66,7 +66,7 @@ function update( options ) {
 	_resembleContainerPath = _resembleContainerPath || getResembleContainerPath( _libraryRoot );
 
 	_src = stripslash( options.screenshotRoot || _src );
-	_results = stripslash( options.comparisonResultRoot || _results || _src );
+	_results = stripslash( options.comparisonResultRoot || _src || _results );
 	_failures = options.failedComparisonsRoot === false ? false : stripslash( options.failedComparisonsRoot || _failures );
 
 	_fileNameGetter = options.fileNameGetter || _fileNameGetter;


### PR DESCRIPTION
Addresses [issue 169](https://github.com/Huddle/PhantomCSS/issues/169) by checking whether options.screenshotRoot contains a value *before* defaulting to an existing _results value.