### PR TITLE
Update location for comparison images when updating the screenshotRoot location

### DIFF
--- a/phantomcss.js
+++ b/phantomcss.js
@@ -66,7 +66,7 @@ function update( options ) {
 	_resembleContainerPath = _resembleContainerPath || getResembleContainerPath( _libraryRoot );
 
 	_src = stripslash( options.screenshotRoot || _src );
-	_results = stripslash( options.comparisonResultRoot || _results || _src );
+	_results = stripslash( options.comparisonResultRoot || options.screenshotRoot || _results || _src );
 	_failures = options.failedComparisonsRoot === false ? false : stripslash( options.failedComparisonsRoot || _failures );
 
 	_fileNameGetter = options.fileNameGetter || _fileNameGetter;


### PR DESCRIPTION
Addresses [Issue 169](https://github.com/Huddle/PhantomCSS/issues/169), problem with multiple tests' comparison images appearing in the first test's snapshot foldler.