### PR TITLE
Allow lower tolerance threshold

### DIFF
--- a/phantomcss.js
+++ b/phantomcss.js
@@ -610,16 +610,17 @@ function initClient() {
 				ignoreAntialiasing(). // <-- muy importante
 				onComplete( function ( data ) {
 					var diffImage;
+					var misMatchPercentage = mismatchTolerance < 0.01 ? data.rawMisMatchPercentage : data.misMatchPercentage;
 
-					if ( Number( data.misMatchPercentage ) > mismatchTolerance ) {
-						result = data.misMatchPercentage;
+					if ( Number( misMatchPercentage ) > mismatchTolerance ) {
+						result = misMatchPercentage;
 					} else {
 						result = false;
 					}
 
 					window._imagediff_.hasResult = true;
 
-					if ( Number( data.misMatchPercentage ) > mismatchTolerance ) {
+					if ( Number( misMatchPercentage ) > mismatchTolerance ) {
 						render( data );
 					}
 

--- a/phantomcss.js
+++ b/phantomcss.js
@@ -82,7 +82,7 @@ function update( options ) {
 
 	_hideElements = options.hideElements;
 
-	_mismatchTolerance = options.mismatchTolerance || _mismatchTolerance;
+	_mismatchTolerance = isNaN(options.mismatchTolerance) ? _mismatchTolerance : options.mismatchTolerance;
 
 	_rebase = isNotUndefined(options.rebase) ? options.rebase : _rebase;
 


### PR DESCRIPTION
Allows thresholds lower than 0.01
Allows threshold to be 0

My use-case is for comparing a very long page, 0.01% difference is actually quite significant. I also require passing `largeImageThreshold` to Resemble.js
This fix allows me to see even the smallest differences on a large page.