### PR TITLE
Add option to fail on capture error and fn hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,8 @@ phantomcss.init({
 		});
 	},
 
+	onCaptureFail: function(ex, target) { console.log('Capture of ' + target + ' failed due to ' + ex.message); }
+
 	/*
 		Change the output screenshot filenames for your specific 
 		integration
@@ -201,7 +203,12 @@ phantomcss.init({
 		images without manually deleting the files
 		casperjs demo/test.js --rebase
 	*/
-	rebase: casper.cli.get("rebase")
+	rebase: casper.cli.get("rebase"),
+
+	/*
+		If true, test will fail when captures fail (e.g. no element matching selector).
+	 */
+	failOnCaptureError: false
 });
 
 /*

--- a/phantomcss.js
+++ b/phantomcss.js
@@ -18,6 +18,7 @@ var _addLabelToFailedImage = true;
 var _mismatchTolerance = 0.05;
 var _resembleOutputSettings = {};
 var _cleanupComparisonImages = false;
+var _failOnCaptureError = false;
 var diffsCreated = [];
 
 var _resemblePath;
@@ -79,6 +80,9 @@ function update( options ) {
 	_onTimeout = options.onTimeout || _onTimeout;
 	_onNewImage = options.onNewImage || _onNewImage;
 	_onComplete = options.onComplete || options.report || _onComplete;
+	_onCaptureFail = options.onCaptureFail || _onCaptureFail;
+
+	_failOnCaptureError = options.failOnCaptureError || _failOnCaptureError;
 
 	_hideElements = options.hideElements;
 
@@ -88,7 +92,7 @@ function update( options ) {
 
 	_resembleOutputSettings = options.outputSettings || _resembleOutputSettings;
 
-	_resembleOutputSettings.useCrossOrigin=false; // turn off x-origin attr in Resemble to support SlimerJS 
+	_resembleOutputSettings.useCrossOrigin=false; // turn off x-origin attr in Resemble to support SlimerJS
 
 	_cleanupComparisonImages = options.cleanupComparisonImages || _cleanupComparisonImages;
 
@@ -312,7 +316,7 @@ function capture( srcPath, resultPath, target ) {
 		}
 
 	} catch ( ex ) {
-		console.log( "[PhantomCSS] Screenshot capture failed: " + ex.message );
+		_onCaptureFail(ex, target)
 	}
 }
 
@@ -635,6 +639,14 @@ function _onPass( test ) {
 	console.log( '\n' );
 	var name = 'Should look the same ' + test.filename;
 	casper.test.pass(name, {name: name});
+}
+
+function _onCaptureFail( ex, target ) {
+	console.log( "[PhantomCSS] Screenshot capture failed: " + ex.message );
+	if (_failOnCaptureError) {
+		var name = 'Capture screenshot ' + target;
+		casper.test.fail(name, {name:name, message: 'Failed to capture ' + target + ' - ' + ex.message });
+	}
 }
 
 function _onFail( test ) {


### PR DESCRIPTION
Adds `failOnCaptureError` option, to make the casperjs tests fail if any screenshots fail to capture.

Adds `onCaptureFail` function hook to customise what happens on screenshot fail.

Addresses https://github.com/Huddle/PhantomCSS/issues/188